### PR TITLE
Bugfix: correcting the 7.5 ms drift in NWB export 

### DIFF
--- a/pipeline/export/nwb.py
+++ b/pipeline/export/nwb.py
@@ -225,7 +225,7 @@ def datajoint_to_nwb(session_key, raw_ephys=False, raw_video=False):
                 go_cue_time = (experiment.SessionTrial * experiment.TrialEvent & session_key & {'trial': trial_number} & {'trial_event_type':'go'}).fetch('trial_event_time', order_by='trial')
                 raw_spike_times.append(aligned_time + float(trial_start) + float(go_cue_time))
             spikes = np.concatenate(raw_spike_times).ravel()
-            observed_times = np.array([trial_start, trial_stop]).T.astype('float')
+            observed_times = np.array([trial_starts, trial_stops]).T.astype('float')
             unit['spike_times'] = spikes
             unit['obs_intervals'] = observed_times
             unit['electrodes'] = electrode_df.query(

--- a/pipeline/export/nwb.py
+++ b/pipeline/export/nwb.py
@@ -221,11 +221,11 @@ def datajoint_to_nwb(session_key, raw_ephys=False, raw_video=False):
         for unit in unit_query.fetch(as_dict=True):
             unit['id'] = max(nwbfile.units.id.data) + 1 if nwbfile.units.id.data else 0
             aligned_times = (ephys.Unit.TrialSpikes & unit).fetch('spike_times')
-            trial_corrected_times = []
+            trial_corrected_times = np.empty_like(aligned_times)
             for go_trial in range(trial_no):
                 trial_start, go_cue_time = np.array((experiment.SessionTrial * experiment.TrialEvent & session_key & {'trial': go_trial+1} & {'trial_event_type':'go'}).fetch1('start_time', 'trial_event_time')).astype('float')
 
-                trial_corrected_times.append(aligned_times[go_trial] + trial_start + go_cue_time)
+                trial_corrected_times[go_trial] = aligned_times[go_trial] + trial_start + go_cue_time
             spikes = np.concatenate(trial_corrected_times).ravel()
             observed_times = np.array((ephys.Unit.TrialSpikes * experiment.SessionTrial & unit).fetch('start_time', 'stop_time')).T.astype('float')
             unit['spike_times'] = spikes

--- a/pipeline/export/nwb.py
+++ b/pipeline/export/nwb.py
@@ -222,7 +222,7 @@ def datajoint_to_nwb(session_key, raw_ephys=False, raw_video=False):
             aligned_times, trial_numbers, trial_starts, trial_stops = (ephys.Unit.TrialSpikes * experiment.SessionTrial & unit).fetch('spike_times', 'trial', 'start_time', 'stop_time', order_by='trial')
             raw_spike_times = []
             for aligned_time, trial_number, trial_start, trial_stop in zip(aligned_times, trial_numbers, trial_starts, trial_stops):
-                go_cue_time = (experiment.SessionTrial * experiment.TrialEvent & session_key & {'trial': trial_number} & {'trial_event_type':'go'}).fetch('trial_event_time', order_by='trial')
+                go_cue_time = (experiment.SessionTrial * experiment.TrialEvent & session_key & {'trial': trial_number} & {'trial_event_type':'go'}).fetch1('trial_event_time', order_by='trial')
                 raw_spike_times.append(aligned_time + float(trial_start) + float(go_cue_time))
             spikes = np.concatenate(raw_spike_times).ravel()
             observed_times = np.array([trial_starts, trial_stops]).T.astype('float')


### PR DESCRIPTION
The solution proposed here follows the logic below: 
1. `Line 164` queries the total number of trials since that will be constant for each probe insertion.
2. `Line 223` fetches spike times for all trials
3. `Lines 225-228` loop through each trial and fetch the trial start time and the go cue start time which are added to the aligned times. 
4. 'Line 229` concatenates the nested arrays into a flattened array
5. `Line 230` queries the trial start and stop times for observed times in NWB file
6. `Line 231` and `line 232` insert spike times and observed time intervals into the NWB file for a particular unit

I'm unsure if this is the most efficient way to query and add this data to the nwbfile. Something like a list comprehension instead of the loop may speed up the current run time of ~3 min 15 seconds per unit in local testing. 